### PR TITLE
Keep side panel open when navigating to CMS edit page

### DIFF
--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -39,22 +39,14 @@ function isSfGovDomain(url: string): boolean {
  */
 async function updateSidePanelForTab(tabId: number, url: string): Promise<void> {
 	try {
-		const isSfGov = isSfGovDomain(url);
-		
-		if (isSfGov) {
-			// enable side panel for SF.gov domains
-			await chrome.sidePanel.setOptions({
-				tabId,
-				enabled: true,
-				path: "src/sidepanel/index.html",
-			});
-		} else {
-			// disable side panel for non-SF.gov domains
-			await chrome.sidePanel.setOptions({
-				tabId,
-				enabled: false,
-			});
-		}
+		// always keep the side panel enabled so it stays open when
+		// switching between SF.gov tabs and CMS admin tabs.  The side
+		// panel UI itself handles non-SF.gov pages gracefully.
+		await chrome.sidePanel.setOptions({
+			tabId,
+			enabled: true,
+			path: "src/sidepanel/index.html",
+		});
 	} catch (err) {
 		console.error(`Side panel update error for tab ${tabId}:`, err);
 	}
@@ -97,8 +89,8 @@ chrome.runtime.onInstalled.addListener(async ({ reason, previousVersion }) => {
 		});
 	}
 
-	// disable side panel by default for all tabs
-	void chrome.sidePanel.setOptions({ enabled: false });
+	// keep the side panel globally enabled so it persists across tab switches
+	void chrome.sidePanel.setOptions({ enabled: true });
 
 	void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 	console.log("SF.gov Companion installed");
@@ -191,13 +183,15 @@ chrome.tabs.onActivated.addListener(async ({ tabId }) => {
 
 /**
  * Listen for tab update events (URL changes within a tab)
+ * Only react to actual URL changes to avoid disabling the side panel
+ * during intermediate loading states (e.g. about:blank)
  */
-chrome.tabs.onUpdated.addListener(async (tabId, _changeInfo, tab) => {
-	if (!tab.url) return;
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+	if (!changeInfo.url) return;
 	
 	try {
-		await updateSidePanelForTab(tabId, tab.url);
-		await updateContextMenuVisibility(tab.url);
+		await updateSidePanelForTab(tabId, changeInfo.url);
+		await updateContextMenuVisibility(changeInfo.url);
 	} catch (err) {
 		console.error("Side panel update handling error:", err);
 	}

--- a/packages/extension/src/sidepanel/components/EditLinkCard.tsx
+++ b/packages/extension/src/sidepanel/components/EditLinkCard.tsx
@@ -9,23 +9,22 @@ interface EditLinkCardProps {
 export const EditLinkCard: React.FC<EditLinkCardProps> = ({ pageId }) => {
 	const editUrl = `https://api.sf.gov/admin/pages/${pageId}/edit/`;
 
-	const handleClick = () => {
+	const handleClick = async () => {
 		trackEvent("edit_button_clicked", {
 			page_id: pageId,
 			trigger: "sidepanel_button"
 		});
+
+		await chrome.tabs.create({ url: editUrl });
 	};
 
 	return (
-		<a
-			href={editUrl}
-			target="_blank"
-			rel="noopener noreferrer"
+		<button
 			onClick={handleClick}
 			className="mb-6 inline-flex items-center gap-2 rounded-sm bg-sfgov-blue px-4 py-2 text-sm font-medium text-white shadow hover:bg-sfgov-blue-hover cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
 		>
 			<EditIcon className="h-4 w-4" aria-hidden="true" />
 			Edit on Karl
-		</a>
+		</button>
 	);
 };

--- a/packages/extension/src/sidepanel/components/PageHeader.tsx
+++ b/packages/extension/src/sidepanel/components/PageHeader.tsx
@@ -15,13 +15,14 @@ export const PageHeader: React.FC<PageHeaderProps> = ({ pageData, currentUrl }) 
 
 	const editUrl = `https://api.sf.gov/admin/pages/${id}/edit/`;
 
-	const handleClick = () => {
+	const handleClick = async () => {
 		trackEvent("edit_button_clicked", {
 			page_id: id,
 			page_url: currentUrl,
 			trigger: "sidepanel_button",
 		});
-		window.open(editUrl, "_blank");
+
+		await chrome.tabs.create({ url: editUrl });
 	};
 
 	return (


### PR DESCRIPTION
Change the side panel from per-tab enable/disable to globally enabled so it persists across tab switches.  Previously the panel would close when clicking Edit on Karl because the new api.sf.gov tab had the panel disabled by default.

Update updateSidePanelForTab to always enable the side panel for every tab instead of only SF.gov domains.  The side panel UI already handles non-SF.gov pages gracefully.

Change the global default from disabled to enabled in the onInstalled handler so the panel is available on all tabs from the start.

Update onUpdated listener to only react to actual URL changes via changeInfo.url, avoiding intermediate about:blank states.

Convert PageHeader from window.open to chrome.tabs.create for the Edit on Karl button.

Convert EditLinkCard from an anchor tag to a button element using chrome.tabs.create for consistent behavior.